### PR TITLE
Fixing the partitioned-heat-equation tutorial

### DIFF
--- a/fenicsxprecice/expression_core.py
+++ b/fenicsxprecice/expression_core.py
@@ -134,7 +134,7 @@ class SegregatedRBFInterpolationExpression(CouplingExpression):
     """
 
     def segregated_interpolant_2d(self, coords_x, coords_y, data):
-        assert(coords_x.shape == coords_y.shape)
+        assert (coords_x.shape == coords_y.shape)
         # create least squares system to approximate a * x ** 2 + b * x + c ~= y
 
         def lstsq_interp(x, y, w): return w[0] * x ** 2 + w[1] * y ** 2 + w[2] * x * y + w[3] * x + w[4] * y + w[5]

--- a/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
@@ -1,42 +1,24 @@
-import ufl
-import dolfinx
-from petsc4py import PETSc
+from ufl import dot, form, dx, inner
+from dolfinx.fem import assemble_scalar, assemble
+import numpy as np
+from mpi4py import MPI
 
-def project(v, target_func, V, bcs=[]):
-    # Ensure we have a mesh and attach to measure
-    #V = target_func.function_space
-    dx = ufl.dx(V.mesh)
-
-    # Define variational problem for projection
-    w = ufl.TestFunction(V)
-    Pv = ufl.TrialFunction(V)
-    a = dolfinx.fem.form(ufl.inner(Pv, w) * dx)
-    L = dolfinx.fem.form(ufl.inner(v, w) * dx)
-
-    # Assemble linear system
-    A = dolfinx.fem.petsc.assemble_matrix(a, bcs)
-    A.assemble()
-    b = dolfinx.fem.petsc.assemble_vector(L)
-    dolfinx.fem.petsc.apply_lifting(b, [a], [bcs])
-    b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    dolfinx.fem.petsc.set_bc(b, bcs)
-
-    # Solve linear system
-    solver = PETSc.KSP().create(A.getComm())
-    solver.setOperators(A)
-    solver.solve(b, target_func.vector)
-
-def compute_errors(u_approx, u_ref, v, total_error_tol=10 ** -4):
+def compute_errors(mesh, u_approx, u_ref, total_error_tol=10 ** -4):
     # compute pointwise L2 error
+    
     error_normalized = (u_ref - u_approx) / u_ref
-    # project onto function space
-    #error_pointwise = project(abs(error_normalized), v)
-    V = u_ref.function_space
-    error_pointwise = project(v, abs(error_normalized), V)
-    # determine L2 norm to estimate total error
-    error_total = ufl.sqrt(dolfinx.fem.assemble(ufl.inner(error_pointwise, error_pointwise) * ufl.dx))
-    error_pointwise.rename("error", " ")
+
+    inner_p = inner(error_normalized, error_normalized)
+    assembly = assemble_scalar(inner_p * dx)
+
+    error_total = np.sqrt(assembly)
+
+    # error_total = np.sqrt(assemble(inner(error_normalized, error_normalized) * dx))
+
+    # error_pointwise = form(dot(u_approx - u_ref, u_approx - u_ref)*dx)
+    # error_total =  np.sqrt(mesh.comm.allreduce(assemble_scalar(error_pointwise), op=MPI.SUM))
 
     assert (error_total < total_error_tol)
 
-    return error_total, error_pointwise
+    # return error_total, error_pointwise
+    return error_total

--- a/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
@@ -1,14 +1,14 @@
-import ufl
-from ufl import dot, dx, inner
-from dolfinx.fem import assemble_scalar, assemble, form
+from ufl import dx
+from dolfinx.fem import assemble_scalar, form
 import numpy as np
 from mpi4py import MPI
 
 
 def compute_errors(u_approx, u_ref, total_error_tol=10 ** -4):
-    # compute pointwise L2 error
     mesh = u_ref.function_space.mesh
-    error_pointwise = form((u_approx - u_ref) ** 2 * dx)
+
+    # compute total L2 error between reference and calculated solution
+    error_pointwise = form(((u_approx - u_ref) / u_ref) ** 2 * dx)
     error_total = np.sqrt(mesh.comm.allreduce(assemble_scalar(error_pointwise), MPI.SUM))
 
     assert (error_total < total_error_tol)

--- a/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
@@ -4,11 +4,12 @@ from dolfinx.fem import assemble_scalar, assemble, form
 import numpy as np
 from mpi4py import MPI
 
+
 def compute_errors(u_approx, u_ref, total_error_tol=10 ** -4):
     # compute pointwise L2 error
     mesh = u_ref.function_space.mesh
-    error_pointwise = form((u_approx - u_ref) ** 2 *dx)
-    error_total =  np.sqrt(mesh.comm.allreduce(assemble_scalar(error_pointwise), MPI.SUM))
+    error_pointwise = form((u_approx - u_ref) ** 2 * dx)
+    error_total = np.sqrt(mesh.comm.allreduce(assemble_scalar(error_pointwise), MPI.SUM))
 
     assert (error_total < total_error_tol)
 

--- a/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/errorcomputation.py
@@ -1,13 +1,40 @@
-from fenics import inner, assemble, dx, project, sqrt
+import ufl
+import dolfinx
+from petsc4py import PETSc
 
+def project(v, target_func, V, bcs=[]):
+    # Ensure we have a mesh and attach to measure
+    #V = target_func.function_space
+    dx = ufl.dx(V.mesh)
+
+    # Define variational problem for projection
+    w = ufl.TestFunction(V)
+    Pv = ufl.TrialFunction(V)
+    a = dolfinx.fem.form(ufl.inner(Pv, w) * dx)
+    L = dolfinx.fem.form(ufl.inner(v, w) * dx)
+
+    # Assemble linear system
+    A = dolfinx.fem.petsc.assemble_matrix(a, bcs)
+    A.assemble()
+    b = dolfinx.fem.petsc.assemble_vector(L)
+    dolfinx.fem.petsc.apply_lifting(b, [a], [bcs])
+    b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+    dolfinx.fem.petsc.set_bc(b, bcs)
+
+    # Solve linear system
+    solver = PETSc.KSP().create(A.getComm())
+    solver.setOperators(A)
+    solver.solve(b, target_func.vector)
 
 def compute_errors(u_approx, u_ref, v, total_error_tol=10 ** -4):
     # compute pointwise L2 error
     error_normalized = (u_ref - u_approx) / u_ref
     # project onto function space
-    error_pointwise = project(abs(error_normalized), v)
+    #error_pointwise = project(abs(error_normalized), v)
+    V = u_ref.function_space
+    error_pointwise = project(v, abs(error_normalized), V)
     # determine L2 norm to estimate total error
-    error_total = sqrt(assemble(inner(error_pointwise, error_pointwise) * dx))
+    error_total = ufl.sqrt(dolfinx.fem.assemble(ufl.inner(error_pointwise, error_pointwise) * ufl.dx))
     error_pointwise.rename("error", " ")
 
     assert (error_total < total_error_tol)

--- a/tutorials/partitioned-heat-conduction/fenicsx/heat.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/heat.py
@@ -264,7 +264,7 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
         if precice.is_time_window_complete():
             u_ref.interpolate(u_D_function)
             # error, error_pointwise = compute_errors(mesh, u_n, u_ref, total_error_tol=error_tol)
-            error = compute_errors(mesh, u_n, u_ref, total_error_tol=error_tol)
+            error = compute_errors(u_n, u_ref, total_error_tol=error_tol)
             print('n = %d, t = %.2f: L2 error on domain = %.3g' % (n, t, error))
             print('output u^%d and u_ref^%d' % (n, n))
             

--- a/tutorials/partitioned-heat-conduction/fenicsx/heat.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/heat.py
@@ -88,7 +88,6 @@ W = V_g.sub(0).collapse()[0]
 
 # Define boundary conditions
 
-
 class Expression_u_D:
     def __init__(self):
         self.t = 0.0
@@ -120,7 +119,6 @@ if problem is ProblemType.DIRICHLET:
 # Define initial value
 u_n = Function(V, name="Temperature")
 u_n.interpolate(u_D.eval)
-# u_n.rename("Temperature", "")
 
 precice, precice_dt, initial_data = None, 0.0, None
 
@@ -182,6 +180,7 @@ t = 0
 # reference solution at t=0
 u_ref = Function(V, name="reference")
 u_ref.interpolate(u_D_function)
+
 '''
 # TODO
 # mark mesh w.r.t ranks
@@ -264,21 +263,17 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
 
         if precice.is_time_window_complete():
             u_ref.interpolate(u_D_function)
-            # TODO
-            ''
-            error, error_pointwise = compute_errors(u_n, u_ref, V, total_error_tol=error_tol)
+            # error, error_pointwise = compute_errors(mesh, u_n, u_ref, total_error_tol=error_tol)
+            error = compute_errors(mesh, u_n, u_ref, total_error_tol=error_tol)
             print('n = %d, t = %.2f: L2 error on domain = %.3g' % (n, t, error))
             print('output u^%d and u_ref^%d' % (n, n))
-            ''
+            
             xdmf.write_function(u_n, t)
-            ''
-            # TODO
+            
             # output solution and reference solution at t_n+1
-            '''
-            temperature_out << u_n
-            ref_out << u_ref
-            error_out << error_pointwise
-            '''
+            # temperature_out << u_n
+            # ref_out << u_ref
+            # error_out << error_pointwise
 
         # Update Dirichlet BC
         u_D.t = t + dt.value

--- a/tutorials/partitioned-heat-conduction/fenicsx/heat.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/heat.py
@@ -88,6 +88,7 @@ W = V_g.sub(0).collapse()[0]
 
 # Define boundary conditions
 
+
 class Expression_u_D:
     def __init__(self):
         self.t = 0.0
@@ -205,7 +206,7 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
     ranks << mesh_rank
     '''
 
-    #error_total, error_pointwise = compute_errors(u_n, u_ref, V) # TODO
+    # error_total, error_pointwise = compute_errors(u_n, u_ref, V) # TODO
     ''
     # TODO
     '''
@@ -267,9 +268,9 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
             error = compute_errors(u_n, u_ref, total_error_tol=error_tol)
             print('n = %d, t = %.2f: L2 error on domain = %.3g' % (n, t, error))
             print('output u^%d and u_ref^%d' % (n, n))
-            
+
             xdmf.write_function(u_n, t)
-            
+
             # output solution and reference solution at t_n+1
             # temperature_out << u_n
             # ref_out << u_ref

--- a/tutorials/partitioned-heat-conduction/fenicsx/heat.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/heat.py
@@ -31,7 +31,7 @@ from dolfinx.fem.petsc import LinearProblem
 from dolfinx.io import XDMFFile
 from ufl import TrialFunction, TestFunction, dx, ds, dot, grad, inner, lhs, rhs, FiniteElement, VectorElement
 from fenicsxprecice import Adapter
-# from errorcomputation import compute_errors  # TODO update do dolfinx
+from errorcomputation import compute_errors  # TODO update do dolfinx
 from my_enums import ProblemType, DomainPart
 import argparse
 import numpy as np
@@ -206,9 +206,10 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
     ranks << mesh_rank
     '''
 
-    # error_total, error_pointwise = compute_errors(u_n, u_ref, V) # TODO
-    '''
+    #error_total, error_pointwise = compute_errors(u_n, u_ref, V) # TODO
+    ''
     # TODO
+    '''
     error_out << error_pointwise
     '''
     u_D.t = t + dt.value
@@ -264,13 +265,16 @@ with XDMFFile(MPI.COMM_WORLD, f"./out/{precice.get_participant_name()}.xdmf", "w
         if precice.is_time_window_complete():
             u_ref.interpolate(u_D_function)
             # TODO
-            # error, error_pointwise = compute_errors(u_n, u_ref, V, total_error_tol=error_tol)
-            # print('n = %d, t = %.2f: L2 error on domain = %.3g' % (n, t, error))
+            ''
+            error, error_pointwise = compute_errors(u_n, u_ref, V, total_error_tol=error_tol)
+            print('n = %d, t = %.2f: L2 error on domain = %.3g' % (n, t, error))
             print('output u^%d and u_ref^%d' % (n, n))
+            ''
             xdmf.write_function(u_n, t)
-            '''
+            ''
             # TODO
             # output solution and reference solution at t_n+1
+            '''
             temperature_out << u_n
             ref_out << u_ref
             error_out << error_pointwise

--- a/tutorials/partitioned-heat-conduction/fenicsx/problem_setup.py
+++ b/tutorials/partitioned-heat-conduction/fenicsx/problem_setup.py
@@ -1,7 +1,6 @@
 """
 Problem setup for partitioned-heat-conduction/fenics-fenics tutorial
 """
-# from dolfinx.fem import Function, VectorFunctionSpace, Expression
 from dolfinx.mesh import DiagonalType, create_rectangle
 from my_enums import DomainPart
 import numpy as np


### PR DESCRIPTION
This PR implements a simplified error computation using functionality from dolfinx. The comparison to the analytical solution at the coupling boundary now works again.