### PR TITLE
Moved mask computation into adapter initialization

### DIFF
--- a/fenicsxprecice/adapter_core.py
+++ b/fenicsxprecice/adapter_core.py
@@ -85,7 +85,7 @@ def determine_function_type(input_obj):
         raise Exception("Error determining type of given dolfin FunctionSpace")
 
 
-def convert_fenicsx_to_precice(fenicsx_function, local_ids):
+def convert_fenicsx_to_precice(fenicsx_function, mask, local_ids):
     """
     Converts data of type dolfin.Function into Numpy array for all x and y coordinates on the boundary.
 
@@ -93,6 +93,8 @@ def convert_fenicsx_to_precice(fenicsx_function, local_ids):
     ----------
     fenicsx_function : FEniCSx function
         A FEniCSx function referring to a physical variable in the problem.
+    mask : numpy array
+        Array of Function degrees of freedom on which the data gets sampled
     local_ids: numpy array
         Array of local indices of vertices on the coupling interface and owned by this rank.
 
@@ -106,18 +108,7 @@ def convert_fenicsx_to_precice(fenicsx_function, local_ids):
         raise Exception("Cannot handle data type {}".format(type(fenicsx_function)))
 
     precice_data = []
-    # sampled_data = fenicsx_function.x.array  # that works only for 1st order elements where dofs = grid points
-    # TODO begin dirty fix. See https://github.com/precice/fenicsx-adapter/issues/17 for details.
-    x_mesh = fenicsx_function.function_space.mesh.geometry.x
-    x_dofs = fenicsx_function.function_space.tabulate_dof_coordinates()
-    mask = []  # where dof coordinate == mesh coordinate
-    for i in range(x_dofs.shape[0]):
-        for j in range(x_mesh.shape[0]):
-            if np.allclose(x_dofs[i, :], x_mesh[j, :], 1e-15):
-                mask.append(i)
-                break
     sampled_data = fenicsx_function.x.array[mask]
-    # end dirty fix
 
     if len(local_ids):
         if fenicsx_function.function_space.num_sub_spaces > 0:  # function space is VectorFunctionSpace
@@ -178,3 +169,5 @@ def get_fenicsx_vertices(function_space, coupling_subdomain, dims):
         ids = np.array(ids)
         coords = np.array(coords)
     return ids, coords
+
+

--- a/fenicsxprecice/adapter_core.py
+++ b/fenicsxprecice/adapter_core.py
@@ -169,5 +169,3 @@ def get_fenicsx_vertices(function_space, coupling_subdomain, dims):
         ids = np.array(ids)
         coords = np.array(coords)
     return ids, coords
-
-

--- a/fenicsxprecice/fenicsxprecice.py
+++ b/fenicsxprecice/fenicsxprecice.py
@@ -64,7 +64,7 @@ class Adapter:
         # coupling mesh related quantities
         self._fenicsx_vertices = Vertices()
         self._precice_vertex_ids = None  # initialized later
-        self._mask = None # initialized later
+        self._mask = None  # initialized later
 
         # read data related quantities (read data is read from preCICE and applied in FEniCSx)
         self._read_function_type = None  # stores whether read function is scalar or vector valued
@@ -185,7 +185,7 @@ class Adapter:
 
         x_mesh = write_function.function_space.mesh.geometry.x
         x_dofs = write_function.function_space.tabulate_dof_coordinates()
-        if(self._mask == None):
+        if (self._mask is None):
             self._mask = []  # where dof coordinate == mesh coordinate
             for i in range(x_dofs.shape[0]):
                 for j in range(x_mesh.shape[0]):
@@ -229,7 +229,7 @@ class Adapter:
         if isinstance(write_object, Function):  # precice.initialize_data() will be called using this Function
             write_function_space = write_object.function_space
             write_function = write_object
-            
+
         elif isinstance(write_object, FunctionSpace):  # preCICE will use default zero values for initialization.
             write_function_space = write_object
             write_function = None
@@ -477,5 +477,3 @@ class Adapter:
             Name of action related to reading a checkpoint.
         """
         return precice.action_read_iteration_checkpoint()
-
-

--- a/tests/unit/test_adapter_core.py
+++ b/tests/unit/test_adapter_core.py
@@ -36,7 +36,16 @@ class TestAdapterCore(TestCase):
             local_ids.append(i)
             manual_sampling.append([fun_lambda(v[0], v[1])])
         manual_sampling = np.array(manual_sampling).squeeze()
+        
+        x_mesh = fenicsx_function.function_space.mesh.geometry.x
+        x_dofs = fenicsx_function.function_space.tabulate_dof_coordinates()
+        mask = []  # where dof coordinate == mesh coordinate
+        for i in range(x_dofs.shape[0]):
+            for j in range(x_mesh.shape[0]):
+                if np.allclose(x_dofs[i, :], x_mesh[j, :], 1e-15):
+                    mask.append(i)
+                    break
 
-        data = convert_fenicsx_to_precice(fenicsx_function, local_ids)
+        data = convert_fenicsx_to_precice(fenicsx_function, mask, local_ids)
 
         np.testing.assert_allclose(data, manual_sampling, atol=10**-16)

--- a/tests/unit/test_adapter_core.py
+++ b/tests/unit/test_adapter_core.py
@@ -36,7 +36,7 @@ class TestAdapterCore(TestCase):
             local_ids.append(i)
             manual_sampling.append([fun_lambda(v[0], v[1])])
         manual_sampling = np.array(manual_sampling).squeeze()
-        
+
         x_mesh = fenicsx_function.function_space.mesh.geometry.x
         x_dofs = fenicsx_function.function_space.tabulate_dof_coordinates()
         mask = []  # where dof coordinate == mesh coordinate


### PR DESCRIPTION
This PR is to move the mask computation into the initialization of the adapter. This also resolves the [issue](https://github.com/precice/fenicsx-adapter/issues/17) about the dirty fix.