### PR TITLE
Install FEniCSx adapter in venv for running tutorials

### DIFF
--- a/.github/workflows/run-tutorials.yml
+++ b/.github/workflows/run-tutorials.yml
@@ -37,6 +37,9 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           pip3 install ../../..
+      - name: Remove fenicsxadapter from requirements to avoid overwriting develop version
+        run: |
+          sed -i '/fenicsxprecice/d' tutorials/partitioned-heat-conduction/solver-fenicsx/requirements.txt
       # Tutorial is currently hosted under https://github.com/precice/fenicsx-adapter, should be moved to https://github.com/precice/tutorials when working. See https://github.com/precice/tutorials/issues/491
       # - name: Get tutorials
       #   run: git clone -b develop https://github.com/precice/tutorials.git

--- a/.github/workflows/run-tutorials.yml
+++ b/.github/workflows/run-tutorials.yml
@@ -27,13 +27,13 @@ jobs:
         run: python3 -c "import dolfinx; print('FEniCS-X version '+dolfinx.__version__)"
       - name: Create venv for Dirichlet participants and install adapter
         run: |
-          cd tutorials/partitioned-heat-conduction/dirichlet-fenics
+          cd tutorials/partitioned-heat-conduction/dirichlet-fenicsx
           python3 -m venv .venv
           . .venv/bin/activate
           pip3 install ../../..
       - name: Create venv for Neumann participants and install adapter
         run: |
-          cd tutorials/partitioned-heat-conduction/neumann-fenics
+          cd tutorials/partitioned-heat-conduction/neumann-fenicsx
           python3 -m venv .venv
           . .venv/bin/activate
           pip3 install ../../..

--- a/.github/workflows/run-tutorials.yml
+++ b/.github/workflows/run-tutorials.yml
@@ -25,8 +25,18 @@ jobs:
           rm -rf /var/lib/apt/lists/*
       - name: Check FEniCSx version
         run: python3 -c "import dolfinx; print('FEniCS-X version '+dolfinx.__version__)"
-      - name: Install adapter
-        run:  pip3 install --user .
+      - name: Create venv for Dirichlet participants and install adapter
+        run: |
+          cd tutorials/partitioned-heat-conduction/dirichlet-fenics
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip3 install ../../..
+      - name: Create venv for Neumann participants and install adapter
+        run: |
+          cd tutorials/partitioned-heat-conduction/neumann-fenics
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip3 install ../../..
       # Tutorial is currently hosted under https://github.com/precice/fenicsx-adapter, should be moved to https://github.com/precice/tutorials when working. See https://github.com/precice/tutorials/issues/491
       # - name: Get tutorials
       #   run: git clone -b develop https://github.com/precice/tutorials.git

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='fenicsxprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsxprecice'],
-      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py'],
+      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py<4'],
       tests_require=['sympy'],
       test_suite='tests',
       zip_safe=False)


### PR DESCRIPTION
## Main changes of this PR

Uses venv to install FEniCSx adapter

## Motivation and additional information

Follows the recommended approach for installing packages in python.