### PR TITLE
Restrict to `mpi4py<4`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='fenicsxprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsxprecice'],
-      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py'],
+      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py<4'],
       tests_require=['sympy'],
       test_suite='tests',
       zip_safe=False)


### PR DESCRIPTION
## Main changes of this PR

Restrict to `mpi4py<4` in `setup.py`

## Motivation and additional information

#33 fails (presumably due to mpi4py problem). In https://github.com/precice/fenics-adapter/pull/181 we implemented the identical fix.

## Author's checklist

* [x] I updated the changelog file `CHANGELOG.md` if there are user-observable changes since the last release. (skipping because this is a rather technical detail and we have not officially released the fenicsx adapter)
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
