### PR TITLE
Remove mpi4py restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## current development
 
+* Remove version restriction on the dependency mpi4py. [#46](https://github.com/precice/fenicsx-adapter/pull/46)
 * Support to handle multiple data fields on one mesh. [#39](https://github.com/precice/fenicsx-adapter/pull/39)
 * Support communication of multiple data fields. [#34](https://github.com/precice/fenicsx-adapter/pull/34)
 * Update to support dolfinx version 0.9.0 and preCICE v3. [#28](https://github.com/precice/fenicsx-adapter/pull/28)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='fenicsxprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsxprecice'],
-      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py<4'],
+      install_requires=['pyprecice~=3.0', 'scipy<1.15.0', 'numpy>=1.13.3', 'mpi4py'],
       tests_require=['sympy'],
       test_suite='tests',
       zip_safe=False)

--- a/tutorials/partitioned-heat-conduction/solver-fenicsx/requirements.txt
+++ b/tutorials/partitioned-heat-conduction/solver-fenicsx/requirements.txt
@@ -1,4 +1,5 @@
-numpy
+numpy >1, <2
 fenicsxprecice
 scipy
 sympy
+mpi4py<4

--- a/tutorials/partitioned-heat-conduction/solver-fenicsx/requirements.txt
+++ b/tutorials/partitioned-heat-conduction/solver-fenicsx/requirements.txt
@@ -1,4 +1,4 @@
-numpy >1, <2
+numpy
 fenicsxprecice
 scipy
 sympy


### PR DESCRIPTION
## Main changes of this PR

This PR removes the restriction of `mpi4py<4` because DOLFINx now works with the latest mpi4py. The partitioned heat conduction tutorial case has the restriction `numpy >1, <2`, which in turn requires mpi4py to be restricted to `<4`. Given this restriction, it is reasonable to move the mpi4py restriction to the tutorial, as it not a restriction from the side of the adapter.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I updated the changelog file `CHANGELOG.md` if there are user-observable changes since the last release.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
